### PR TITLE
Feature/18 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ typings/
 .vscode/
 .DS_Store
 buildRelease*.sh
+.cloud

--- a/app/pages/sponsor/event-detail/event-detail.html
+++ b/app/pages/sponsor/event-detail/event-detail.html
@@ -17,7 +17,7 @@
                     <Label col="0" class="icon icon-2x person-icon text-muted text-center" text="&#xf206;" *ngIf="ticket"></Label>
                     <StackLayout col="1" class="medium-spacing" orientation="vertical" *ngIf="ticket">
                         <Label class="title" [text]="ticket.fullName"></Label>
-                        <Label [text]="ticket.email"></Label>
+                        <Label [text]="ticket.uuid"></Label>
                     </StackLayout>
                     <StackLayout col="1" class="medium-spacing" orientation="vertical" *ngIf="!ticket">
                         <Label class="title" text="Synchronization in progress..." ></Label>

--- a/app/pages/staff/event-detail/event-detail.html
+++ b/app/pages/staff/event-detail/event-detail.html
@@ -17,7 +17,6 @@
             <StackLayout *ngIf="isStatusSuccess()" orientation="vertical">
                 <Label [text]="ticket.fullName" class="h2 text-center"></Label>
                 <Label [text]="ticket.categoryName" class="h2 text-center"></Label>
-                <Label text="{{ticket.email}}" class="h6 text-center"></Label>
                 <Label text="{{ticket.uuid}}" class="h6 text-center"></Label>
             </StackLayout>
         </StackLayout>


### PR DESCRIPTION
So, there are 2 situation where email are shown in the event details:

event-detail page in the sponsor section: email to be replaced by uuid
event-detail page in the staff section: email to be removed